### PR TITLE
Update GitHub workflow dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,15 @@
 name: CIFSyntaxandStyleCheck
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
             - '.github/**'
 
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
             - '.github/**'
   workflow_dispatch:
@@ -63,7 +63,7 @@ jobs:
                 repository: jamesrhester/julia_cif_tools
                 path: julia_cif_tools
 
-      - name: Checkout CIF master files
+      - name: Checkout CIF_CORE main branch files
         uses: actions/checkout@v4
         with:
                 repository: COMCIFS/cif_core

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
     branches: [ master ]
     paths-ignore:
             - '.github/**'
-  workflow_dispatch:   
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -45,7 +45,7 @@ jobs:
                  key: ${{ runner.os }}-julia-v2
                  
       - name: Install Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
                 version: '1.6'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Get the cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
                  path: ~/.julia


### PR DESCRIPTION
The 'actions/cache' in particular needs updating since v2 will stop being supported on 2025-03-01.

For more information, see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down.

Also, the name of the main branch was left unchanged after the renaming thus preventing any tests from being run.