### PR TITLE
Slater terms

### DIFF
--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -16,7 +16,7 @@ data_CIF_RHO
     _dictionary.version           2.0.3
     _dictionary.date              2026-04-16
     _dictionary.uri
-https://raw.githubusercontent.com/COMCIFS/cif_rho/refs/heads/main/cif_rho.dic
+        https://raw.githubusercontent.com/COMCIFS/cif_rho/main/cif_rho.dic
     _dictionary.ddl_conformance   4.2.0
     _dictionary.licensing_SPDX    CC-BY-4.0
     _dictionary.namespace         CifCore

--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -14,7 +14,7 @@ data_CIF_RHO
     _dictionary.title             CIF_RHO
     _dictionary.class             Instance
     _dictionary.version           2.0.3
-    _dictionary.date              2026-01-19
+    _dictionary.date              2026-04-15
     _dictionary.uri
 ;\
 https://raw.githubusercontent.com/COMCIFS/Electron_Density_\
@@ -72,7 +72,7 @@ save_ATOM_LOCAL_AXES
     multipole formalism proposed by Hansen & Coppens (1978). In
     this model, the electron density in a crystal is described
     by a sum of aspherical "pseudoatoms" where the pseudoatom
-    density has the form defined in the _atom_rho_multipole_* items.
+    density has the form defined in the _atom_rho_multipole* items.
     Each pseudoatom density consists of terms representing the
     core density, the spherical part of the valence density and
     the deviation of the valence density from sphericity. The
@@ -119,7 +119,7 @@ save_atom_local_axes.atom0
     vectors. In most cases, atom1 will be the same as the atom
     specified by _atom_local_axes.atom_label. One or more 'dummy'
     atoms (with arbitrary labels) may be used in the vector
-    definitions, specified with zero occupancy in the _atom_site.*
+    definitions, specified with zero occupancy in the ATOM_SITE
     description.  The values of *_atom0, *_atom1 and *_atom2 must
     be identical to values given in the _atom_site.label list.
 ;
@@ -216,7 +216,7 @@ save_atom_local_axes.ax1
     vectors. In most cases, atom1 will be the same as the atom
     specified by _atom_local_axes.atom_label. One or more 'dummy'
     atoms (with arbitrary labels) may be used in the vector
-    definitions, specified with zero occupancy in the _atom_site.*
+    definitions, specified with zero occupancy in the ATOM_SITE
     description.  The values of *_atom0, *_atom1 and *_atom2 must
     be identical to values given in the _atom_site.label list.
 ;
@@ -313,7 +313,7 @@ save_ATOM_RHO_MULTIPOLE
     & Coppens (1978). In this model, the electron density in
     a crystal is described by a sum of aspherical "pseudoatoms"
     where the pseudoatom density has the form defined in the
-    _atom_rho_multipole_* items. Each pseudoatom density
+    _atom_rho_multipole* items. Each pseudoatom density
     consists of terms representing the core density, the spherical
     part of the valence density and the deviation of the valence
     density from sphericity. The continuous electron density in the
@@ -401,8 +401,8 @@ save_atom_rho_multipole.core_source
     _type.contents                Text
     _description_example.case
 ;
-    Clementi, E. & Roetti, C. (1974). At. Data Nucl. Data Tables,
-    14, 177-478.
+    Clementi, E. & Roetti, C. (1974). At. Data Nucl. Data
+    Tables, 14, 177-478.
 ;
 
 save_
@@ -2045,6 +2045,34 @@ save_atom_rho_multipole_radial_slater.n3_su
 
 save_
 
+save_atom_rho_multipole_radial_slater.n4
+
+    _definition.id                '_atom_rho_multipole_radial_slater.n4'
+    _alias.definition_id          '_atom_rho_multipole_radial_slater_n4'
+    _name.category_id             atom_rho_multipole_radial_slater
+    _name.object_id               n4
+
+    _import.get                   [{'file':templ_attr.cif  'save':rho_slater}]
+
+save_
+
+save_atom_rho_multipole_radial_slater.n4_su
+
+    _definition.id                '_atom_rho_multipole_radial_slater.n4_su'
+    _definition.update            2026-04-15
+    _description.text
+;
+    Standard uncertainty of _atom_rho_multipole_radial_slater.n4.
+;
+    _name.category_id             atom_rho_multipole_radial_slater
+    _name.object_id               n4_su
+    _name.linked_item_id          '_atom_rho_multipole_radial_slater.n4'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
 save_atom_rho_multipole_radial_slater.n_list
 
     _definition.id                '_atom_rho_multipole_radial_slater.n_list'
@@ -2262,6 +2290,34 @@ save_atom_rho_multipole_radial_slater.zeta3_su
 
 save_
 
+save_atom_rho_multipole_radial_slater.zeta4
+
+    _definition.id                '_atom_rho_multipole_radial_slater.zeta4'
+    _alias.definition_id          '_atom_rho_multipole_radial_slater_zeta4'
+    _name.category_id             atom_rho_multipole_radial_slater
+    _name.object_id               zeta4
+
+    _import.get                   [{'file':templ_attr.cif  'save':rho_slater}]
+
+save_
+
+save_atom_rho_multipole_radial_slater.zeta4_su
+
+    _definition.id                '_atom_rho_multipole_radial_slater.zeta4_su'
+    _definition.update            2026-04-15
+    _description.text
+;
+    Standard uncertainty of _atom_rho_multipole_radial_slater.zeta4.
+;
+    _name.category_id             atom_rho_multipole_radial_slater
+    _name.object_id               zeta4_su
+    _name.linked_item_id          '_atom_rho_multipole_radial_slater.zeta4'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
 save_atom_rho_multipole_radial_slater.zeta_list
 
     _definition.id                '_atom_rho_multipole_radial_slater.zeta_list'
@@ -2381,7 +2437,7 @@ save_
 ;
        Update import statements, improve DDLm conformance.
 ;
-         2.0.3                    2026-01-19
+         2.0.3                    2026-04-15
 ;
        Further improve DDLm conformance. Add missing su data names.
 
@@ -2413,4 +2469,7 @@ save_
        (av)
 
        Changed name of Head category in accordance with convention. (bm)
+
+       Added _atom_rho_multipole_radial_slater.n3 and
+       _atom_rho_multipole_radial_slater.zeta4. (bm)
 ;

--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -14,13 +14,11 @@ data_CIF_RHO
     _dictionary.title             CIF_RHO
     _dictionary.class             Instance
     _dictionary.version           2.0.3
-    _dictionary.date              2026-04-15
+    _dictionary.date              2026-04-16
     _dictionary.uri
-;\
-https://raw.githubusercontent.com/COMCIFS/Electron_Density_\
-Dictionary/master/cif_rho.dic
-;
+https://raw.githubusercontent.com/COMCIFS/cif_rho/refs/heads/main/cif_rho.dic
     _dictionary.ddl_conformance   4.2.0
+    _dictionary.licensing_SPDX    CC-BY-4.0
     _dictionary.namespace         CifCore
     _description.text
 ;
@@ -2059,7 +2057,7 @@ save_
 save_atom_rho_multipole_radial_slater.n4_su
 
     _definition.id                '_atom_rho_multipole_radial_slater.n4_su'
-    _definition.update            2026-04-15
+    _definition.update            2026-04-16
     _description.text
 ;
     Standard uncertainty of _atom_rho_multipole_radial_slater.n4.
@@ -2304,7 +2302,7 @@ save_
 save_atom_rho_multipole_radial_slater.zeta4_su
 
     _definition.id                '_atom_rho_multipole_radial_slater.zeta4_su'
-    _definition.update            2026-04-15
+    _definition.update            2026-04-16
     _description.text
 ;
     Standard uncertainty of _atom_rho_multipole_radial_slater.zeta4.
@@ -2425,6 +2423,15 @@ save_atom_rho_multipole_radial_slater.zeta_list_su
 
 save_
 
+#=============================================================================
+#  The dictionary's creation history.
+#============================================================================
+
+    _dictionary_author.id         1
+    _dictionary_author.name       'Mallinson, P. R.'
+    _dictionary_author.id_orcid   .
+    _dictionary_author.email      .
+
     loop_
       _dictionary_audit.version
       _dictionary_audit.date
@@ -2437,7 +2444,7 @@ save_
 ;
        Update import statements, improve DDLm conformance.
 ;
-         2.0.3                    2026-04-15
+         2.0.3                    2026-04-16
 ;
        Further improve DDLm conformance. Add missing su data names.
 


### PR DESCRIPTION
Added _atom_rho_multipole_radial_slater.n3 and _atom_rho_multipole_radial_slater.zeta4, which seemed to have been missed in the initial conversion from DDL1. Also fixed current dictionary URL and added licensing and author info and a few style tweaks.